### PR TITLE
Ansibleuser Branch to Master(Enhancing security by not using root)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 ansible-control
 ansible-node
-./volshare/base_machine_id_rsa.pub
+volshare/base_machine_id_rsa.pub
+volshare/control_machine_id_rsa.pub
+volshare/passwd.yml
+volshare/testit.sh

--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ Setup Instructions:
 1. Clone the repository: git clone https://github.com/ITLearnersAcademy/Ansible-Learning.git
 2. Change directory: cd Ansible-Learning
 3. Run the setup script: ./setup_ansible_learn.sh 
+4. Make a note of the "ansible" user's password by displaying logs using the command "sudo docker logs ansible-control".
+   Note: You need this password to supply to ansible commands which require privilege escalation to root (eg: as an option to --ask-sudo-pass) 
 
 Usage Instructions:
 1. Open Terminal on your machine
-2. To connect to Ansible Control host: ssh root@ansible-control
-3. To connect to nodes from Control host: ssh root@node1 or ssh root@node2
+2. To connect to Ansible Control host: ssh ansible@ansible-control
+3. To connect to nodes from Control host: ssh ansible@node1 or ssh ansible@node2
 4. To check connectivity between control host and nodes: cd /workspace; ansible all -i hosts -m ping
 Note: You can only connect to nodes from the control host and won't be able to connect directy from your Docker Host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
        - node2
   node1:
     container_name: ansible-node1
-    image: itla/ansible-node:v2
+    image: itla/ansible-node:v3
     ports:
        - "9023:22"
     volumes:
@@ -41,7 +41,7 @@ services:
     restart: always
   node2:
     container_name: ansible-node2
-    image: itla/ansible-node:v2
+    image: itla/ansible-node:v3
     ports:
        - "9024:22"
     volumes:

--- a/volshare/setup_control_node.sh
+++ b/volshare/setup_control_node.sh
@@ -25,7 +25,9 @@ then
     randString=$(date|md5sum)
     IFS=" "; randInput=($randString); unset IFS
     randPassword=${randInput[0]}
-    echo "Random Password $randPassword"
+    echo "------------Make Note:------------------------"
+    echo "Ansible and Root user's password ($hostname): $randPassword"
+    echo "----------------------------------------------"
     echo "root:$randPassword" | chpasswd
     echo "ansible:$randPassword" | chpasswd
     chown -R ansible:ansible /home/ansible/.ssh/    

--- a/volshare/setup_control_node.sh
+++ b/volshare/setup_control_node.sh
@@ -1,37 +1,45 @@
 #!/bin/bash
-# setup ssh keys for root which will be used for communication between Control node and other nodes
-if [ ! -f ~/.ssh/id_rsa ]; then
-    ssh-keygen -q -f ~/.ssh/id_rsa -N ""
+# create ansible user for the normal operations
+# setup ssh keys for ansible user which will be used for communication between Control node and other nodes
+grep -q "ansible" /etc/passwd
+if [ $? -ne 0 ]; then
+    useradd -d /home/ansible -m -s /bin/bash -p ansible ansible
+    usermod -aG sudo ansible
+    mkdir /home/ansible/.ssh
+    ssh-keygen -q -f /home/ansible/.ssh/id_rsa -N ""
+    sed -i 's/root@control.ansiblelearn.io/ansible@control.ansiblelearn.io/' /home/ansible/.ssh/id_rsa.pub
+    cp /home/ansible/.ssh/id_rsa.pub /workspace/control_machine_id_rsa.pub
 fi
 
 # Enable passwordless autentication from Docker Host to Ansible Control node
-base_machine_ssh_pub_key=$(cat base_machine_id_rsa.pub)
-grep -q "$base_machine_ssh_pub_key" ~/.ssh/authorized_keys
-if [ $? -ne 0 ]; then
-    echo "Docker Host User's id_rsa.pub not in ~/.ssh/authorized_keys list. Adding it to enable Passwordless Authentication"
-    echo "$base_machine_ssh_pub_key" > ~/.ssh/authorized_keys
+base_machine_ssh_pub_key=$(cat /workspace/base_machine_id_rsa.pub)
+grep -q "$base_machine_ssh_pub_key" /home/ansible/.ssh/authorized_keys
+if [ $? -ne 0 ]
+then
+    echo "Docker Host User's id_rsa.pub not in /home/ansible/.ssh/authorized_keys list. Adding it to enable Passwordless Authentication"
+    echo "$base_machine_ssh_pub_key" > /home/ansible/.ssh/authorized_keys
     # Disable PasswordAuthentication in sshd_config file
     sed -i 's/PermitRootLogin yes/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
     sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
-    # Change password for root user to a random string
+    # Change password for root, ansible users to a random string
     randString=$(date|md5sum)
     IFS=" "; randInput=($randString); unset IFS
     randPassword=${randInput[0]}
-    echo $randPassword
-    echo "root:$randPassword" | chpasswd    
+    echo "Random Password $randPassword"
+    echo "root:$randPassword" | chpasswd
+    echo "ansible:$randPassword" | chpasswd
+    chown -R ansible:ansible /home/ansible/.ssh/    
 else
-    echo "Unable to establish Passwordless Authentication between Docker Host and Ansible Control node!"
+    echo "Passwordless Authentication between Docker Host and Ansible Control node already established!"
 fi
 
 # Enable Passwordless Authentication between Ansible Control node and other nodes for Control to Node communication
 nodeList=$(cat hosts)
 for node in $nodeList
 do
-    output=$(sshpass -p "screencast"  ssh-copy-id -o "StrictHostKeyChecking no" -i ~/.ssh/id_rsa root@$node)
-    if [ ! -z "$output" ]; then
-        # Disable PasswordAuthentication and change password on nodes
-        cat setup_nodes.sh | ssh root@$node
-    fi    
+    # Disable PasswordAuthentication and change password on nodes
+    echo "Enabling Passwordless Authentication between Ansible Control node and other nodes for Control to Node communication"
+    cat setup_nodes.sh | sshpass -p "screencast" ssh -o "StrictHostKeyChecking no" root@$node
 done
 
 # Run SSH in Daemon Mode

--- a/volshare/setup_nodes.sh
+++ b/volshare/setup_nodes.sh
@@ -22,7 +22,9 @@ if [ $? -ne 0 ]; then
     randString=$(date|md5sum)
     IFS=" "; randInput=($randString); unset IFS
     randPassword=${randInput[0]}
-    echo $randPassword
+    echo "------------Make Note:------------------------"
+    echo "Ansible and Root user's password ($hostname): $randPassword"
+    echo "----------------------------------------------"
     echo "root:$randPassword" | chpasswd
     echo "ansible:$randPassword" | chpasswd
     chown -R ansible:ansible /home/ansible/.ssh/

--- a/volshare/setup_nodes.sh
+++ b/volshare/setup_nodes.sh
@@ -1,11 +1,32 @@
 echo "Working on node: $(hostname)"
-# Disable PasswordAuthentication in sshd_config file
-sed -i 's/PermitRootLogin yes/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
-sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
-# Change password for root user to a random string
-randString=$(date|md5sum)
-IFS=" "; randInput=($randString); unset IFS
-randPassword=${randInput[0]}
-echo $randPassword
-echo "root:$randPassword" | chpasswd
+# create a normal user with sudo privileges if user doesn't exist
+grep -q "ansible" /etc/passwd
+if [ $? -ne 0 ]; then
+    useradd -d /home/ansible -m -s /bin/bash -p ansible ansible
+    usermod -aG sudo ansible
+    mkdir /home/ansible/.ssh
+    ssh-keygen -q -f /home/ansible/.ssh/id_rsa -N ""
+    sed -i "s/root@$(hostname)/ansible@$(hostname)/" /home/ansible/.ssh/id_rsa.pub
+fi
+
+# Enable passwordless autentication from Control Host to node
+control_machine_ssh_pub_key=$(cat /workspace/control_machine_id_rsa.pub)
+grep -q "$control_machine_ssh_pub_key" /home/ansible/.ssh/authorized_keys
+if [ $? -ne 0 ]; then
+    echo "Control Host ansible User's id_rsa.pub not in /home/ansible/.ssh/authorized_keys list. Adding it to enable Passwordless Authentication"
+    echo "$control_machine_ssh_pub_key" > /home/ansible/.ssh/authorized_keys
+    # Disable PasswordAuthentication in sshd_config file as root user
+    sed -i 's/PermitRootLogin yes/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+    sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
+    # Change password for root,ansible user to a random string
+    randString=$(date|md5sum)
+    IFS=" "; randInput=($randString); unset IFS
+    randPassword=${randInput[0]}
+    echo $randPassword
+    echo "root:$randPassword" | chpasswd
+    echo "ansible:$randPassword" | chpasswd
+    chown -R ansible:ansible /home/ansible/.ssh/
+else
+    echo "Passwordless Authentication between Ansible Control host and node already established!"
+fi
 


### PR DESCRIPTION
1. Default ssh to control host and nodes use "ansible" as the user instead of "root". "ansible" user granted sudo permissions
2. Updated README.md file to reflect changes